### PR TITLE
🔀 Merge : "feature/categorysearch 브랜치 병합"

### DIFF
--- a/src/main/java/alcoholboot/toastit/feature/defaultcocktail/controller/CocktailController.java
+++ b/src/main/java/alcoholboot/toastit/feature/defaultcocktail/controller/CocktailController.java
@@ -43,7 +43,7 @@ public class CocktailController {
     @GetMapping("/all/ingredient")
     public String getCocktailsByIngredient(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam @NotEmpty String ingredient,
+            @RequestParam @NotEmpty List<String> ingredient,
             Model model) {
 
         Page<Cocktail> cocktailPage = cocktailService.getCocktailsByIngredientPaged(ingredient, PageRequest.of(page, 20));
@@ -54,7 +54,7 @@ public class CocktailController {
 
         model.addAttribute("totalPages", cocktailPage.getTotalPages());
 
-        model.addAttribute("ingredient", ingredient);
+        model.addAttribute("ingredient", String.join(",", ingredient));
 
         return "feature/defaultcocktail/cocktailIngredient";
     }
@@ -71,7 +71,7 @@ public class CocktailController {
 
         model.addAttribute("totalPages", cocktails.getTotalPages());
 
-        model.addAttribute("glass", glass);
+        model.addAttribute("glass", String.join(",", glass));
         return "feature/defaultcocktail/cocktailGlass";
     }
 
@@ -84,14 +84,14 @@ public class CocktailController {
         model.addAttribute("cocktails", cocktails);
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", cocktails.getTotalPages());
-        model.addAttribute("type", type);
+        model.addAttribute("type", String.join(", ", type));
         return "feature/defaultcocktail/cocktailType";
     }
 
     @GetMapping("/all/complex")
     public String getCocktailsByComplex(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(required = false) String ingredient,
+            @RequestParam(required = false) List<String> ingredient,
             @RequestParam(required = false) String glass,
             @RequestParam(required = false) String type,
             Model model) {
@@ -104,14 +104,14 @@ public class CocktailController {
         model.addAttribute("cocktails", cocktails.getContent());
 
         // 입력된 값만 모델에 추가
-        if (ingredient != null && !ingredient.trim().isEmpty()) {
-            model.addAttribute("ingredient", ingredient);
+        if (ingredient != null && !ingredient.isEmpty()) {
+            model.addAttribute("ingredient", String.join(", ", ingredient));
         }
-        if (glass != null && !glass.trim().isEmpty()) {
-            model.addAttribute("glass", glass);
+        if (glass != null && !glass.isEmpty()) {
+            model.addAttribute("glass", String.join(", ", glass));
         }
-        if (type != null && !type.trim().isEmpty()) {
-            model.addAttribute("type", type);
+        if (type != null && !type.isEmpty()) {
+            model.addAttribute("type", String.join(", ", type));
         }
 
         return "feature/defaultcocktail/cocktailComplex";

--- a/src/main/java/alcoholboot/toastit/feature/defaultcocktail/repository/custom/CustomCocktailRepository.java
+++ b/src/main/java/alcoholboot/toastit/feature/defaultcocktail/repository/custom/CustomCocktailRepository.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 public interface CustomCocktailRepository {
     // 각 기능에 페이징 기능을 추가하기 위해서 추가
-    Page<CocktailDocument> findCocktailsByIngredientPage(String ingredient, Pageable pageable);
+    Page<CocktailDocument> findCocktailsByIngredientPage(List<String> ingredient, Pageable pageable);
     Page<CocktailDocument> findCocktailsByGlassPage(String glass, Pageable pageable);
     Page<CocktailDocument> findCocktailsByCategoryPage(String category, Pageable pageable);
-    Page<CocktailDocument> findByIngredientAndGlass(String ingredient, String glass, Pageable pageable);
-    Page<CocktailDocument> findByIngredientAndCategoryPage(String ingredient, String category, Pageable pageable);
+    Page<CocktailDocument> findByIngredientAndGlass(List<String> ingredient, String glass, Pageable pageable);
+    Page<CocktailDocument> findByIngredientAndCategoryPage(List<String> ingredient, String category, Pageable pageable);
     Page<CocktailDocument> findByGlassAndCategoryPage(String glass, String category, Pageable pageable);
-    Page<CocktailDocument> findByIngredientAndGlassAndCategoryPage(String ingredient, String glass, String category, Pageable pageable);
+    Page<CocktailDocument> findByIngredientAndGlassAndCategoryPage(List<String> ingredient, String glass, String category, Pageable pageable);
 
     // 랜덤 레시피를 반환
     List<CocktailDocument> findRandomCocktails(int count);

--- a/src/main/java/alcoholboot/toastit/feature/defaultcocktail/repository/custom/Impl/CustomCocktailRepositoryImpl.java
+++ b/src/main/java/alcoholboot/toastit/feature/defaultcocktail/repository/custom/Impl/CustomCocktailRepositoryImpl.java
@@ -21,14 +21,35 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
     private final MongoTemplate mongoTemplate;
 
     /**
+     * 복수의 재료 검색을 위한 Criteria를 생성합니다.
+     * 이 메서드는 strIngredient1부터 strIngredient11까지의 필드에 대해 검색 조건을 생성합니다.
+     *
+     * @param ingredients 검색할 복수의 재료 이름
+     * @return 생성된 Criteria 객체
+     */
+    private Criteria createIngredientCriteria(List<String> ingredients) {
+        if (ingredients == null || ingredients.isEmpty()) {
+            return new Criteria();
+        }
+
+        // 복수 키워드를 적용하기 위해, 단일 키워드를 연결하는 방식으로 진행
+        List<Criteria> allIngredientsCriteria = ingredients.stream()
+                .map(this::createSingleIngredientCriteria)
+                .toList();
+
+        // 크기를 0으로 하면 Java에서 반환될 크기를 자동으로 결정한다.
+        return new Criteria().andOperator(allIngredientsCriteria.toArray(new Criteria[0]));
+    }
+
+    /**
      * 재료 검색을 위한 Criteria를 생성합니다.
      * 이 메서드는 strIngredient1부터 strIngredient11까지의 필드에 대해 검색 조건을 생성합니다.
      *
      * @param ingredient 검색할 재료 이름
      * @return 생성된 Criteria 객체
      */
-    private Criteria createIngredientCriteria(String ingredient) {
-        if (ingredient == null || ingredient.trim().isEmpty()) {
+    private Criteria createSingleIngredientCriteria(String ingredient) {
+        if (ingredient == null || ingredient.isEmpty()) {
             return new Criteria();
         }
         return new Criteria().orOperator(
@@ -57,7 +78,8 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
             return new Criteria();
         }
         return new Criteria().orOperator(
-                Criteria.where("strGlass").regex(glass, "i")
+                // regex -> in 으로 수정
+                Criteria.where("strGlass").in(glass, "i")
         );
     }
 
@@ -72,7 +94,7 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
             return new Criteria();
         }
         return new Criteria().orOperator(
-                Criteria.where("strCategory").regex(category, "i")
+                Criteria.where("strCategory").in(category, "i")
         );
     }
 
@@ -101,7 +123,7 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
      * 주어진 재료로 칵테일을 검색합니다.
      */
     @Override
-    public Page<CocktailDocument> findCocktailsByIngredientPage(String ingredient, Pageable pageable) {
+    public Page<CocktailDocument> findCocktailsByIngredientPage(List<String> ingredient, Pageable pageable) {
 
         return findCocktails(createIngredientCriteria(ingredient), pageable);
     }
@@ -128,7 +150,7 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
      * 주어진 재료와 잔 종류로 칵테일을 검색합니다.
      */
     @Override
-    public Page<CocktailDocument> findByIngredientAndGlass(String ingredient, String glass, Pageable pageable) {
+    public Page<CocktailDocument> findByIngredientAndGlass(List<String> ingredient, String glass, Pageable pageable) {
 
         // Criteria 생성
         Criteria combinedCriteria = new Criteria().andOperator(
@@ -143,7 +165,7 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
      * 주어진 재료와 카테고리로 칵테일을 검색합니다.
      */
     @Override
-    public Page<CocktailDocument> findByIngredientAndCategoryPage(String ingredient, String category, Pageable pageable) {
+    public Page<CocktailDocument> findByIngredientAndCategoryPage(List<String> ingredient, String category, Pageable pageable) {
 
         // Criteria 생성
         Criteria combinedCriteria = new Criteria().andOperator(
@@ -173,7 +195,7 @@ public class CustomCocktailRepositoryImpl implements CustomCocktailRepository {
      * 주어진 재료, 잔 종류, 카테고리로 칵테일을 검색합니다.
      */
     @Override
-    public Page<CocktailDocument> findByIngredientAndGlassAndCategoryPage(String ingredient, String glass, String category, Pageable pageable) {
+    public Page<CocktailDocument> findByIngredientAndGlassAndCategoryPage(List<String> ingredient, String glass, String category, Pageable pageable) {
 
         // Criteria 생성
         Criteria combinedCriteria = new Criteria().andOperator(

--- a/src/main/java/alcoholboot/toastit/feature/defaultcocktail/service/CocktailService.java
+++ b/src/main/java/alcoholboot/toastit/feature/defaultcocktail/service/CocktailService.java
@@ -12,13 +12,13 @@ public interface CocktailService {
     // 카테고리 검색
     List<Cocktail> getAllCocktails();
     Page<Cocktail> getAllCocktailsPaged(Pageable pageable);
-    Page<Cocktail> getCocktailsByIngredientPaged(String ingredient, Pageable pageable);
+    Page<Cocktail> getCocktailsByIngredientPaged(List<String> ingredient, Pageable pageable);
     Page<Cocktail> getCocktailsByGlassPaged(String glass, Pageable pageable);
     Page<Cocktail> getCocktailsByTypePaged(String type, Pageable pageable);
-    Page<Cocktail> getCocktailsByIngredientAndGlassPaged(String ingredient, String glass, Pageable pageable);
-    Page<Cocktail> getCocktailsByIngredientAndTypePaged(String ingredient, String type, Pageable pageable);
+    Page<Cocktail> getCocktailsByIngredientAndGlassPaged(List<String> ingredient, String glass, Pageable pageable);
+    Page<Cocktail> getCocktailsByIngredientAndTypePaged(List<String> ingredient, String type, Pageable pageable);
     Page<Cocktail> getCocktailsByGlassAndTypePaged(String glass, String type, Pageable pageable);
-    Page<Cocktail> getCocktailsByFilterPaged(String ingredient, String glass, String type, Pageable pageable);
+    Page<Cocktail> getCocktailsByFilterPaged(List<String> ingredient, String glass, String type, Pageable pageable);
     Optional<Cocktail> getCocktailById(ObjectId id);
 
     // 랜덤한 칵테일 반환

--- a/src/main/java/alcoholboot/toastit/feature/defaultcocktail/service/impl/CocktailServiceImpl.java
+++ b/src/main/java/alcoholboot/toastit/feature/defaultcocktail/service/impl/CocktailServiceImpl.java
@@ -38,7 +38,7 @@ public class CocktailServiceImpl implements CocktailService {
 
     // 카테고리 적용 - 재료
     @Override
-    public Page<Cocktail> getCocktailsByIngredientPaged(String ingredient, Pageable pageable) {
+    public Page<Cocktail> getCocktailsByIngredientPaged(List<String> ingredient, Pageable pageable) {
         return cocktailRepository.findCocktailsByIngredientPage(ingredient, pageable)
                 .map(CocktailDocument::convertToDomain);
     }
@@ -58,13 +58,13 @@ public class CocktailServiceImpl implements CocktailService {
     }
 
     @Override
-    public Page<Cocktail> getCocktailsByIngredientAndGlassPaged(String ingredient, String glass, Pageable pageable) {
+    public Page<Cocktail> getCocktailsByIngredientAndGlassPaged(List<String> ingredient, String glass, Pageable pageable) {
         return cocktailRepository.findByIngredientAndGlass(ingredient, glass, pageable)
                 .map(CocktailDocument::convertToDomain);
     }
 
     @Override
-    public Page<Cocktail> getCocktailsByIngredientAndTypePaged(String ingredient, String type, Pageable pageable) {
+    public Page<Cocktail> getCocktailsByIngredientAndTypePaged(List<String> ingredient, String type, Pageable pageable) {
         return cocktailRepository.findByIngredientAndCategoryPage(ingredient, type, pageable)
                 .map(CocktailDocument::convertToDomain);
     }
@@ -77,7 +77,7 @@ public class CocktailServiceImpl implements CocktailService {
 
     // 카테고리 적용 - 복합
     @Override
-    public Page<Cocktail> getCocktailsByFilterPaged(String ingredient, String glass, String type, Pageable pageable) {
+    public Page<Cocktail> getCocktailsByFilterPaged(List<String> ingredient, String glass, String type, Pageable pageable) {
         return cocktailRepository.findByIngredientAndGlassAndCategoryPage(ingredient, glass, type, pageable)
                 .map(CocktailDocument::convertToDomain);
     }

--- a/src/main/resources/static/css/defaultcocktail/defaultcocktail.css
+++ b/src/main/resources/static/css/defaultcocktail/defaultcocktail.css
@@ -54,9 +54,9 @@ body {
     display: grid;
     color: black;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    margin-left: 2rem;
-    margin-right: 2rem;
-    gap: 20px;
+    gap: 160px;
+    row-gap: 55px;
+    margin: auto 15rem;
 }
 
 .cocktail-item {
@@ -97,11 +97,23 @@ body {
     color: white;
 }
 
+#search-guide {
+    text-align: center;
+    color: #666666;
+    font-size: 15px;
+    margin-bottom: -5px;
+}
+
 .cocktail-buttons {
     display: flex;
     justify-content: center;
     gap: 10px;
     margin-bottom: 20px;
+    transition: margin-right 0.1s ease;
+}
+
+.cocktail-buttons.search-hidden {
+    margin-right: 63px;
 }
 
 .cocktail-button {

--- a/src/main/resources/static/css/defaultcocktail/defaultcocktaildetail.css
+++ b/src/main/resources/static/css/defaultcocktail/defaultcocktaildetail.css
@@ -100,6 +100,14 @@ h2 {
     background-color: #e08a2b;
 }
 
+.back-button-container{
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 2px;
+    margin-right: 2rem;
+}
+
 .back-button {
     display: block;
     width: 100%;

--- a/src/main/resources/static/js/defaultcocktail/detail.js
+++ b/src/main/resources/static/js/defaultcocktail/detail.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const backToSearchButton = document.getElementById('backToSearchResult');
+    const lastSearchUrl = sessionStorage.getItem('lastSearchUrl');
+
+    if (lastSearchUrl.includes('/cocktails/all/complex')) {
+        backToSearchButton.style.display = 'block';
+        backToSearchButton.href = lastSearchUrl;
+    }
+});

--- a/src/main/resources/static/js/defaultcocktail/formVail.js
+++ b/src/main/resources/static/js/defaultcocktail/formVail.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('form');
+    const lastSearchUrl = sessionStorage.getItem('lastSearchUrl')
 
     // 폼 제출 이벤트 처리
     if (form) {
@@ -16,33 +17,8 @@ document.addEventListener('DOMContentLoaded', function() {
             if (isEmpty) {
                 event.preventDefault();
                 alert('검색하려면 최소 하나의 필드를 입력해야 합니다.');
-            } else {
-                // 복합 검색 URL 생성
-                const ingredient = document.getElementById('ingredientInput').value.trim();
-                const glass = document.getElementById('glassInput').value.trim();
-                const category = document.getElementById('categoryInput').value.trim();
-
-                let url = '/cocktails/all';
-                let params = [];
-
-                if (ingredient) params.push(`ingredient=${encodeURIComponent(ingredient)}`);
-                if (glass) params.push(`glass=${encodeURIComponent(glass)}`);
-                if (category) params.push(`type=${encodeURIComponent(category)}`);
-
-                if (params.length === 1) {
-                    if (ingredient) url += '/ingredient';
-                    else if (glass) url += '/glass';
-                    else if (category) url += '/type';
-                } else if (params.length > 1) {
-                    url += '/complex';
-                }
-
-                if (params.length > 0) {
-                    url += '?' + params.join('&');
-                }
-
-                event.preventDefault();
-                window.location.href = url;
+            }else{
+                window.location.href = lastSearchUrl;
             }
         });
     }

--- a/src/main/resources/static/js/defaultcocktail/search.js
+++ b/src/main/resources/static/js/defaultcocktail/search.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const searchButton = document.getElementById('searchButton');
+    const ingredientInput = document.getElementById('ingredientInput');
+    const glassInput = document.getElementById('glassInput');
+    const categoryInput = document.getElementById('categoryInput');
+
+    if (searchButton) {
+        searchButton.addEventListener('click', function() {
+            // 복합 검색 URL 생성
+            const ingredient = ingredientInput.value.trim();
+            const glass = glassInput.value.trim();
+            const category = categoryInput.value.trim();
+
+            let url = '/cocktails/all';
+            let params = [];
+
+            if (ingredient) params.push(`ingredient=${encodeURIComponent(ingredient)}`);
+            if (glass) params.push(`glass=${encodeURIComponent(glass)}`);
+            if (category) params.push(`type=${encodeURIComponent(category)}`);
+
+            if (params.length > 0) {
+                url += '/complex' + '?' + params.join('&');
+                sessionStorage.setItem('lastSearchUrl', url)
+            }
+        });
+    }
+});

--- a/src/main/resources/static/js/defaultcocktail/toggle.js
+++ b/src/main/resources/static/js/defaultcocktail/toggle.js
@@ -1,49 +1,27 @@
 document.addEventListener('DOMContentLoaded', function() {
     const toggleButton = document.getElementById('toggleSearch');
     const searchOptions = document.getElementById('searchOptions');
-    const searchButton = document.getElementById('searchButton');
-    const ingredientInput = document.getElementById('ingredientInput');
-    const glassInput = document.getElementById('glassInput');
-    const categoryInput = document.getElementById('categoryInput');
+    const searchGuide = document.getElementById('search-guide');
+    const cocktailButtons = document.querySelector('.cocktail-buttons');
 
-    if (toggleButton && searchOptions) {
+    if (toggleButton && searchOptions && searchGuide && cocktailButtons) {
         toggleButton.addEventListener('click', function() {
             if (searchOptions.style.display === 'none') {
                 searchOptions.style.display = 'block';
+                searchGuide.style.display = 'block';
                 toggleButton.textContent = '검색 옵션 숨기기';
+                cocktailButtons.classList.add('search-hidden');
             } else {
                 searchOptions.style.display = 'none';
+                searchGuide.style.display = 'none';
                 toggleButton.textContent = '검색 옵션 토글';
+                cocktailButtons.classList.remove('search-hidden');
             }
         });
     }
 
-    if (searchButton) {
-        searchButton.addEventListener('click', function() {
-            const ingredient = ingredientInput.value.trim();
-            const glass = glassInput.value.trim();
-            const category = categoryInput.value.trim();
-
-            let url = '/cocktails/all';
-            let params = [];
-
-            if (ingredient) params.push(`ingredient=${encodeURIComponent(ingredient)}`);
-            if (glass) params.push(`glass=${encodeURIComponent(glass)}`);
-            if (category) params.push(`type=${encodeURIComponent(category)}`);
-
-            if (params.length === 1) {
-                if (ingredient) url += '/ingredient';
-                else if (glass) url += '/glass';
-                else if (category) url += '/type';
-            } else if (params.length > 1) {
-                url += '/complex';
-            }
-
-            if (params.length > 0) {
-                url += '?' + params.join('&');
-            }
-
-            window.location.href = url;
-        });
+    // 페이지 로드 시 초기 상태 설정
+    if (searchOptions.style.display === 'none') {
+        cocktailButtons.classList.remove('search-hidden');
     }
 });

--- a/src/main/resources/templates/feature/defaultcocktail/cocktailComplex.html
+++ b/src/main/resources/templates/feature/defaultcocktail/cocktailComplex.html
@@ -7,6 +7,7 @@
     <link th:href="@{/css/defaultcocktail/defaultcocktail.css}" rel="stylesheet">
 
     <script th:src="@{/js/defaultcocktail/toggle.js}" defer></script>
+    <script th:src="@{/js/defaultcocktail/search.js}" defer></script>
     <script th:src="@{/js/defaultcocktail/formVail.js}" defer></script>
 
     <title>칵테일 복합 검색</title>
@@ -16,7 +17,13 @@
 
 <hr class="divider">
 
-<h1>칵테일 복합 검색</h1>
+<div class="default-banner">
+    <img src="/image/cocktail-banner.jpg" alt="Cocktail Banner">
+    <h1>세계의 칵테일</h1>
+    <p>이런 칵테일은 어떠세요?</p>
+</div>
+
+<p id="search-guide" style="display: none">검색은 쉼표(,)로 구분합니다. 최소 하나 이상의 검색어를 넣어주세요</p>
 
 <div class="cocktail-buttons">
     <button id="toggleSearch" class="cocktail-button">검색 옵션 토글</button>

--- a/src/main/resources/templates/feature/defaultcocktail/cocktailDetails.html
+++ b/src/main/resources/templates/feature/defaultcocktail/cocktailDetails.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link th:href="@{/css/fragment/navbar-fragment.css}" rel="stylesheet">
     <link th:href="@{/css/defaultcocktail/defaultcocktaildetail.css}" rel="stylesheet">
+
+    <script th:src="@{/js/defaultcocktail/detail.js}" defer></script>
     <title th:text="${cocktail.isPresent() ? cocktail.get().strDrink : '칵테일 상세 정보'}">칵테일 상세 정보</title>
 </head>
 <body>
@@ -36,7 +38,26 @@
         <ul class="ingredient-list">
             <li th:if="${cocktail.get().strIngredient1 != null and !cocktail.get().strIngredient1.isEmpty()}"
                 th:text="${cocktail.get().strIngredient1 + (cocktail.get().strMeasure1 != null and !cocktail.get().strMeasure1.isEmpty() ? ' - ' + cocktail.get().strMeasure1 : '')}"></li>
-            <!-- 추가 재료 목록 -->
+            <li th:if="${cocktail.get().strIngredient2 != null and !cocktail.get().strIngredient2.isEmpty()}"
+                th:text="${cocktail.get().strIngredient2 + (cocktail.get().strMeasure2 != null and !cocktail.get().strMeasure2.isEmpty() ? ' - ' + cocktail.get().strMeasure2 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient3 != null and !cocktail.get().strIngredient3.isEmpty()}"
+                th:text="${cocktail.get().strIngredient3 + (cocktail.get().strMeasure3 != null and !cocktail.get().strMeasure3.isEmpty() ? ' - ' + cocktail.get().strMeasure3 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient4 != null and !cocktail.get().strIngredient4.isEmpty()}"
+                th:text="${cocktail.get().strIngredient4 + (cocktail.get().strMeasure4 != null and !cocktail.get().strMeasure4.isEmpty() ? ' - ' + cocktail.get().strMeasure4 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient5 != null and !cocktail.get().strIngredient5.isEmpty()}"
+                th:text="${cocktail.get().strIngredient5 + (cocktail.get().strMeasure5 != null and !cocktail.get().strMeasure5.isEmpty() ? ' - ' + cocktail.get().strMeasure5 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient6 != null and !cocktail.get().strIngredient6.isEmpty()}"
+                th:text="${cocktail.get().strIngredient6 + (cocktail.get().strMeasure6 != null and !cocktail.get().strMeasure6.isEmpty() ? ' - ' + cocktail.get().strMeasure6 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient7 != null and !cocktail.get().strIngredient7.isEmpty()}"
+                th:text="${cocktail.get().strIngredient7 + (cocktail.get().strMeasure7 != null and !cocktail.get().strMeasure7.isEmpty() ? ' - ' + cocktail.get().strMeasure7 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient8 != null and !cocktail.get().strIngredient8.isEmpty()}"
+                th:text="${cocktail.get().strIngredient8 + (cocktail.get().strMeasure8 != null and !cocktail.get().strMeasure8.isEmpty() ? ' - ' + cocktail.get().strMeasure8 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient9 != null and !cocktail.get().strIngredient9.isEmpty()}"
+                th:text="${cocktail.get().strIngredient9 + (cocktail.get().strMeasure9 != null and !cocktail.get().strMeasure9.isEmpty() ? ' - ' + cocktail.get().strMeasure9 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient10 != null and !cocktail.get().strIngredient10.isEmpty()}"
+                th:text="${cocktail.get().strIngredient10 + (cocktail.get().strMeasure10 != null and !cocktail.get().strMeasure10.isEmpty() ? ' - ' + cocktail.get().strMeasure10 : '')}"></li>
+            <li th:if="${cocktail.get().strIngredient11 != null and !cocktail.get().strIngredient11.isEmpty()}"
+                th:text="${cocktail.get().strIngredient11 + (cocktail.get().strMeasure11 != null and !cocktail.get().strMeasure11.isEmpty() ? ' - ' + cocktail.get().strMeasure11 : '')}"></li>
         </ul>
     </div>
 
@@ -58,6 +79,7 @@
 
 <div class="back-button-container">
     <a href="/cocktails/all" class="back-button">목록으로 돌아가기</a>
+    <a id="backToSearchResult" style="display: none;" class="back-button">검색 결과로 돌아가기</a>
 </div>
 
 <script>

--- a/src/main/resources/templates/feature/defaultcocktail/cocktailList.html
+++ b/src/main/resources/templates/feature/defaultcocktail/cocktailList.html
@@ -7,6 +7,7 @@
     <link th:href="@{/css/defaultcocktail/defaultcocktail.css}" rel="stylesheet">
 
     <script th:src="@{/js/defaultcocktail/toggle.js}" defer></script>
+    <script th:src="@{/js/defaultcocktail/search.js}" defer></script>
     <script th:src="@{/js/defaultcocktail/formVail.js}" defer></script>
 
     <title>칵테일 목록</title>
@@ -22,6 +23,7 @@
     <p>이런 칵테일은 어떠세요?</p>
 </div>
 
+<p id="search-guide" style="display: none">검색은 쉼표(,)로 구분합니다. 최소 하나 이상의 검색어를 넣어주세요</p>
 
 <div class="cocktail-buttons">
     <button id="toggleSearch" class="cocktail-button">검색 옵션 토글</button>


### PR DESCRIPTION
- 기본 레시피 검색 기능을 다소 개편했습니다.

1. 재료의 경우 복수의 필드(키워드) 를 적용시켜 검색 할 수 있습니다.(보드카, 커피)
   - 복수의 필드(키워드)를 적용할 시 구분은 쉼표(,)로 합니다.
   - 술 잔과 카테고리의 경우 여전히 단일 필드(키워드) 로만 입력받을 수 있습니다.
   - 이에따른 repository와 service의 코드들의 수정이 있었습니다.

2. 검색 결과를 복합검색으로 통합했습니다.
   - 재료, 술 잔, 카테고리중 하나에만 필드(키워드)를 적용해서 검색하면 해당 검색 결과로 넘어갔지만 이제 검색 결과는 복합 검색으로만 이뤄집니다.

3. 기존에 적용하던 toggle.js를 용도에 맞게 분리하였습니다.
   - toggle.js 하나에 기능을 몰아서 개발하였지만, 이를 기능에 따라 나눴습니다. 
     - detail : coctailDeatil에만 적용합니다. 만약 검색 이력이 있다면 이전 검색 기록으로 돌아갑니다.
     - formVail : 필드를 하나 이상 입력해야 하는 기능과 실제 이동을 담당합니다. 
     - search : 검색하고자 하는 url을 생성합니다. 
     - toggle : 검색 버튼의 토글만을 담당하도록 변경하였습니다.

4. 뷰가 다소 변경되었습니다.
   - 검색 버튼이 토글될 시 간단한 안내문구가 같이 출력됩니다.
   - 상세페이지의 재료를 추가했습니다.